### PR TITLE
Ignore event state '*' and add more tests

### DIFF
--- a/lib/mixins/state-machine.js
+++ b/lib/mixins/state-machine.js
@@ -50,11 +50,15 @@ module.exports = function StateMachine(Model, settings) {
   /**
    * Extract all the possible events from the 'from' and 'to' keys in the state array
    */
-  function getEventStates(events) {
+  Model.getEventStates = function getEventStates(events) {
     const result = []
 
     // Loop through the defined events
     events.forEach(event => {
+      // Ignore a value un from that is not a valid state
+      if (event.from === '*') {
+        return
+      }
       // Create an array if 'from' is a string value
       if (typeof event.from === 'string') {
         event.from = [ event.from ]
@@ -71,21 +75,19 @@ module.exports = function StateMachine(Model, settings) {
   /**
    * Extract the names of the events
    */
-  function getEventNames(events) {
+  Model.getEventNames = function getEventNames(events) {
     const result = []
 
-    // Loop through the defined events
-    events.forEach(event => {
-      // Get the name of the state
-      result.push(event.name)
-    })
+    // Loop through the defined events and get the name of the state
+    events.forEach(event => result.push(event.name))
+
     // Return the unique values in the results
     return _.uniq(result)
   }
 
   // Get the valid event states and names
-  const validStates = getEventStates(settings.events)
-  const validNames = getEventNames(settings.events)
+  const validStates = Model.getEventStates(settings.events)
+  const validNames = Model.getEventNames(settings.events)
 
   debug('Valid event states for property "%s": %o', settings.stateProperty, validStates)
   debug('Valid event names for property "%s": %o', settings.stateProperty, validNames)

--- a/test/test.js
+++ b/test/test.js
@@ -147,3 +147,31 @@ describe('Validation', function() {
     })
   })
 })
+
+describe('Get event states and names', function() {
+
+  const testEvents = [
+    { name: 'activate', from: [ 'none' ], to: 'active' },
+    { name: 'cancel', from: 'active', to: 'canceled' },
+    { name: 'reactivate', from: 'canceled', to: 'active' },
+    { name: 'expire', from: [ 'none', 'active', 'canceled' ], to: 'expired' },
+    { name: 'expire', from: '*', to: 'expired' },
+  ]
+
+  it('should extract the event states', function(done) {
+    const stateEvents = Subscription.getEventStates(testEvents)
+
+    expect(stateEvents.length).to.equal(4)
+    expect(stateEvents).to.include('none', 'active', 'canceled', 'expired')
+    done()
+  })
+
+  it('should extract the event names', function(done) {
+    const stateNames = Subscription.getEventNames(testEvents)
+
+    expect(stateNames.length).to.equal(4)
+    expect(stateNames).to.include('activate', 'cancel', 'reactivate', 'expire')
+    done()
+  })
+
+})


### PR DESCRIPTION
Hey @mrfelton, I've added these 2 methods `getEventStates` and `getEventNames` on the Model, I couldn't find another way to test those in the unit test. Please lmk if there is a better way.

Also, reading the source code of fsm-as-promised I figured that `*` is a [valid 'from' value](https://github.com/vstirbu/fsm-as-promised/blob/master/lib/index.js#L37), I thought it makes sense to exclude it from the array of valid values.
